### PR TITLE
Elements and campaigns2

### DIFF
--- a/app/src/components/sidebar/recent-chats.tsx
+++ b/app/src/components/sidebar/recent-chats.tsx
@@ -91,8 +91,8 @@ function ChatListItem(props: { chat: any, onClick: any, selected: boolean }) {
             },
             onConfirm: async () => {
                 try {
-                    await backend.current?.deleteChat(c.chatID);
-                    context.chat.deleteChat(c.chatID);
+                    await backend.current?.deleteChatAndRelatedData(c.chatID);
+                    context.chat.deleteChatAndRelatedData(c.chatID);
                     navigate('/');
                 } catch (e) {
                     console.error(e);

--- a/app/src/core/backend.ts
+++ b/app/src/core/backend.ts
@@ -2,7 +2,7 @@ import EventEmitter from 'events';
 import * as Y from 'yjs';
 import { encode, decode } from '@msgpack/msgpack';
 import { MessageTree } from './chat/message-tree';
-import { tokenCount, Chat, Summary } from './chat/types';
+import { tokenCount, Chat, SummaryMinimal, SummaryDetailed } from './chat/types';
 import { AsyncLoop } from "./utils/async-loop";
 import { ChatManager } from '.';
 import { getRateLimitResetTimeFromResponse } from './utils';
@@ -277,22 +277,20 @@ export class Backend extends EventEmitter {
         return response.json();
     }
 
-    async saveSummary(summary: Summary) {
+    async saveSummary(summary: SummaryDetailed) {
         return this.post(endpoint + '/save-summary', summary);
     }
 
-    async getSummaries(chatID: string): Promise<Summary[]> {
-        const summaries = await this.get(`${endpoint}/get-summaries?chatID=${chatID}`);
+    async getSummaries(campaignID: string, chatID: string): Promise<SummaryMinimal[]> {
+        const summaries = await this.get(`${endpoint}/get-summaries?chatID=${chatID}&campaignID=${campaignID}`);
         console.log("summaries from server:", summaries);
         return summaries;
-
     }
-
     
-    async saveTokensSinceLastSummary(chatID: string, tokenCount: number, lastSummarizedMessageID?: string) {
-        console.log("save tokens api called by backend.ts, token count: ", tokenCount)
+    async saveTokensSinceLastSummary(chatID: string, campaignID: string, tokenCount: number, lastSummarizedMessageID?: string) {
         const data = {
             chatID: chatID,
+            campaignID: campaignID,
             tokenCount: tokenCount,
             lastSummarizedMessageID: lastSummarizedMessageID || null
         };
@@ -301,8 +299,8 @@ export class Backend extends EventEmitter {
     }
     
     
-    async getTokensSinceLastSummary(chatID: string): Promise<tokenCount> {
-        const reply = await this.get(`${endpoint}/get-tokens-since-last-summary?chatID=${chatID}`);
+    async getTokensSinceLastSummary(campaignID: string, chatID: string): Promise<tokenCount> {
+        const reply = await this.get(`${endpoint}/get-tokens-since-last-summary?chatID=${chatID}&campaignID=${campaignID}`);
         console.log("getTokensSinceLastSummary reply from server:", reply);
     
         return {

--- a/app/src/core/backend.ts
+++ b/app/src/core/backend.ts
@@ -241,7 +241,7 @@ export class Backend extends EventEmitter {
         return null;
     }
 
-    async deleteChat(id: string) {
+    async deleteChatAndRelatedData(id: string) {
         if (!this.isAuthenticated) {
             return;
         }

--- a/app/src/core/chat/types.ts
+++ b/app/src/core/chat/types.ts
@@ -1,3 +1,4 @@
+import { type } from "os";
 import { MessageTree } from "./message-tree";
 
 export interface Parameters {
@@ -54,12 +55,23 @@ export interface tokenCount {
     tokenCount: number | undefined;
     lastSummarizedMessageID: string | undefined;
 }
-    
-export interface Summary {
+
+export interface SummaryMinimal {
     summaryID: string;
+    summary: string;
+}
+    
+export type SummaryDetailed = SummaryMinimal & {
+    campaignID: string;
     chatID: string;
     messageIDs: string[];
-    summary: string;
+}
+
+export interface Campaign {
+    id: string;
+    title: string;
+    description: string;
+    data: string;
 }
 
 export function serializeChat(chat: Chat): string {

--- a/app/src/core/index.ts
+++ b/app/src/core/index.ts
@@ -216,7 +216,7 @@ export class ChatManager extends EventEmitter {
         return this.doc.getChatIDs().map(id => this.get(id));
     }
 
-    public deleteChat(id: string, broadcast = true) {
+    public deleteChatAndRelatedData(id: string, broadcast = true) {
         this.doc.delete(id);
         this.search.delete(id);
     }

--- a/server/src/database/index.ts
+++ b/server/src/database/index.ts
@@ -24,7 +24,7 @@ export default abstract class Database {
     public abstract getDeletedChatIDs(userID: string): Promise<string[]>;
 
     public abstract saveSummary(summaryID: string, userID: string, campaignID: string, chatID: string, messageIDs: string[], summary: string): Promise<void>;
-    public abstract getSummaries(userID: string, chatID: string): Promise<{ userID: string, chatID: string, messageIDs: string[], summary: string}[]>;
+    public abstract getSummaries(userID: string, campaignID: string, chatID: string): Promise<{ chatID: string, messageIDs: string[], summary: string}[]>;
     public abstract saveTokensSinceLastSummary(userID: string, campaignID: string, chatID: string, tokenCount: number, lastSummarizedMessageID?: string): Promise<void>;
     public abstract getTokensSinceLastSummary(userID: string, campaignID: string, chatID: string): Promise<{tokenCount: number | undefined, lastSummarizedMessageID: string | undefined}>;
 

--- a/server/src/database/index.ts
+++ b/server/src/database/index.ts
@@ -20,13 +20,18 @@ export default abstract class Database {
     public abstract insertMessages(userID: string, messages: any[]): Promise<void>;
     public abstract createShare(userID: string|null, id: string): Promise<boolean>;
     public abstract setTitle(userID: string, chatID: string, title: string): Promise<void>;
-    public abstract deleteChat(userID: string, chatID: string): Promise<any>;
+    public abstract deleteChatAndRelatedData(userID: string, chatID: string): Promise<any>;
     public abstract getDeletedChatIDs(userID: string): Promise<string[]>;
-    public abstract saveSummary(summaryID: string, userID: string, chatID: string, messageIDs: string[], summary: string): Promise<void>;
-    public abstract getSummaries(userID: string, chatID: string): Promise<{ userID: string, chatID: string, messageIDs: string[], summary: string}[]>;
-    public abstract saveTokensSinceLastSummary(userID: string, chatID: string, tokenCount: number, lastSummarizedMessageID?: string): Promise<void>;
-    public abstract getTokensSinceLastSummary(userID: string, chatID: string): Promise<{tokenCount: number | undefined, lastSummarizedMessageID: string | undefined}>;
 
+    public abstract saveSummary(summaryID: string, userID: string, campaignID: string, chatID: string, messageIDs: string[], summary: string): Promise<void>;
+    public abstract getSummaries(userID: string, chatID: string): Promise<{ userID: string, chatID: string, messageIDs: string[], summary: string}[]>;
+    public abstract saveTokensSinceLastSummary(userID: string, campaignID: string, chatID: string, tokenCount: number, lastSummarizedMessageID?: string): Promise<void>;
+    public abstract getTokensSinceLastSummary(userID: string, campaignID: string, chatID: string): Promise<{tokenCount: number | undefined, lastSummarizedMessageID: string | undefined}>;
+
+    public abstract saveCampaign(userID: string, campaignID: string, title: string, description: string): Promise<void>;
+    public abstract getCampaigns(userID: string): Promise<{id: string, title: string, description: string}[]>;
+    public abstract getCampaign(userID: string, campaignID: string): Promise<{id: string, title: string, description: string, data: string}>;
+    public abstract deleteCampaign(userID: string, campaignID: string): Promise<void>;
 
     protected abstract loadYDoc(userID: string): Promise<Doc>;
     public abstract saveYUpdate(userID: string, update: Uint8Array): Promise<void>;

--- a/server/src/database/knex.ts
+++ b/server/src/database/knex.ts
@@ -5,6 +5,8 @@ import { config } from '../config';
 
 const tableNames = {
     authentication: 'authentication',
+    campaigns: 'campaigns',
+    storyElements: 'story_elements',
     chats: 'chats',
     deletedChats: 'deleted_chats',
     messages: 'messages',
@@ -34,7 +36,24 @@ export default class KnexDatabaseAdapter extends Database {
             table.binary('salt');
         });
 
-        await this.createTableIfNotExists(tableNames.chats, (table) => {
+        await this.createTableIfNotExists(tableNames.campaigns, (table) => {
+            table.text('id').primary();
+            table.text('user_id');
+            table.text('title');
+            table.text('description');
+        });
+
+        await this.createTableIfNotExists(tableNames.storyElements, (table) => {
+            table.text('id').primary();
+            table.text('user_id');
+            table.text('campaign_id');
+            table.text('type');
+            table.text('name');
+            table.text('description');
+            table.json('associations').defaultTo('[]');
+        });
+
+        await this.createTableIfNotExists(tableNames.chats, (table) => { //"scenes"
             table.text('id').primary();
             table.text('user_id');
             table.text('title');

--- a/server/src/endpoints/delete-chat.ts
+++ b/server/src/endpoints/delete-chat.ts
@@ -1,9 +1,9 @@
 import express from 'express';
 import RequestHandler from "./base";
 
-export default class DeleteChatRequestHandler extends RequestHandler {
+export default class deleteChatAndRelatedDataRequestHandler extends RequestHandler {
     async handler(req: express.Request, res: express.Response) {
-        await this.context.database.deleteChat(this.userID!, req.body.id);
+        await this.context.database.deleteChatAndRelatedData(this.userID!, req.body.id);
         res.json({ status: 'ok' });
     }
 

--- a/server/src/endpoints/get-summaries.ts
+++ b/server/src/endpoints/get-summaries.ts
@@ -5,18 +5,23 @@ export default class GetSummariesHandler extends RequestHandler {
     
     async handler(req: express.Request, res: express.Response) {
     
-        // Validate that chatID is provided and is a string
         if (typeof req.query.chatID !== 'string') {
             res.status(400).send({ message: 'Invalid or missing chatID' });
             return;
         }
+
+        if (typeof req.query.campaignID !== 'string') {
+            res.status(400).send({ message: 'Invalid or missing campaignID' });
+            return;
+        }
     
         const chatID = req.query.chatID;
+        const campaignID = req.query.campaignID;
     
         // Use the userID from the base class
         const userID = this.userID!;
     
-        const summaries = await this.context.database.getSummaries(userID, chatID);
+        const summaries = await this.context.database.getSummaries(userID, campaignID, chatID);
         res.status(200).send(summaries);
     }
 

--- a/server/src/endpoints/get-tokens-since-last-summary.ts
+++ b/server/src/endpoints/get-tokens-since-last-summary.ts
@@ -12,12 +12,13 @@ export default class GetTokensSinceLastSummaryHandler extends RequestHandler {
         }
     
         const chatID = req.query.chatID;
+        const campaignID = req.query.campaignID;
     
         // Use the userID from the base class
         const userID = this.userID!;
     
         try {
-            const result = await this.context.database.getTokensSinceLastSummary(userID, chatID);
+            const result = await this.context.database.getTokensSinceLastSummary(userID, campaignID, chatID);
             console.log("GetTokensSinceLastSummaryHandler got: ", result);
             
             res.status(200).send(result);  // This sends both tokenCount and lastSummarizedMessageID to the client

--- a/server/src/endpoints/get-tokens-since-last-summary.ts
+++ b/server/src/endpoints/get-tokens-since-last-summary.ts
@@ -5,9 +5,13 @@ export default class GetTokensSinceLastSummaryHandler extends RequestHandler {
     
     async handler(req: express.Request, res: express.Response) {
     
-        // Validate that chatID is provided and is a string
         if (typeof req.query.chatID !== 'string') {
             res.status(400).send({ message: 'Invalid or missing chatID' });
+            return;
+        }
+
+        if (typeof req.query.campaignID !== 'string') {
+            res.status(400).send({ message: 'Invalid or missing campaignID' });
             return;
         }
     

--- a/server/src/endpoints/save-summary.ts
+++ b/server/src/endpoints/save-summary.ts
@@ -6,8 +6,8 @@ export default class SaveSummaryHandler extends RequestHandler {
     async handler(req: express.Request, res: express.Response) {
         console.log("SaveSummaryHandler called: ", req.body);
         
-        const { summaryID, chatID, messageIDs, summary } = req.body;
-        await this.context.database.saveSummary(summaryID, this.userID!, chatID, messageIDs, summary);
+        const { summaryID, campaignID, chatID, messageIDs, summary } = req.body;
+        await this.context.database.saveSummary(summaryID, this.userID!, campaignID, chatID, messageIDs, summary);
         //res.status(200).send({ message: 'Summary saved successfully.' });
 
     }

--- a/server/src/endpoints/save-tokens-since-last-summary.ts
+++ b/server/src/endpoints/save-tokens-since-last-summary.ts
@@ -5,8 +5,8 @@ export default class SaveTokensSinceLastSummaryHandler extends RequestHandler {
     
     async handler(req: express.Request, res: express.Response) {
 
-        const { chatID, tokenCount, lastSummarizedMessageID } = req.body;
-        await this.context.database.saveTokensSinceLastSummary(this.userID!, chatID, tokenCount, lastSummarizedMessageID);
+        const { chatID, campaignID, tokenCount, lastSummarizedMessageID } = req.body;
+        await this.context.database.saveTokensSinceLastSummary(this.userID!, campaignID, chatID, tokenCount, lastSummarizedMessageID);
         res.status(200).send({ message: 'Tokens saved successfully.' });
 
     }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,7 +11,7 @@ import Database from './database/index';
 import KnexDatabaseAdapter from './database/knex';
 import GetShareRequestHandler from './endpoints/get-share';
 import HealthRequestHandler from './endpoints/health';
-import DeleteChatRequestHandler from './endpoints/delete-chat';
+import deleteChatAndRelatedDataRequestHandler from './endpoints/delete-chat';
 import ElevenLabsTTSProxyRequestHandler from './endpoints/service-proxies/elevenlabs/text-to-speech';
 import ElevenLabsVoicesProxyRequestHandler from './endpoints/service-proxies/elevenlabs/voices';
 import OpenAIProxyRequestHandler from './endpoints/service-proxies/openai';
@@ -96,7 +96,7 @@ export default class ChatServer {
             max: config.rateLimit.max,
         }));
         
-        this.app.post('/chatapi/delete', (req, res) => new DeleteChatRequestHandler(this, req, res));
+        this.app.post('/chatapi/delete', (req, res) => new deleteChatAndRelatedDataRequestHandler(this, req, res));
         this.app.get('/chatapi/share/:id', (req, res) => new GetShareRequestHandler(this, req, res));
         this.app.post('/chatapi/share', (req, res) => new ShareRequestHandler(this, req, res));
 


### PR DESCRIPTION
Refactored api and backend data functions to use campaignID (EXCEPT CHATS). Dummy ID passed for now. 
Broke summary type into minimal and detailed.
Remove some no longer needed logging
Renamed deleteChat to deleteChatAndRelevantData, now deletes token counts associated with the chat
Added starter campaign table and funtions in knex.ts